### PR TITLE
Display Google Maps notifications even if they are ongoing (fixes #46)

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/services/NLService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/NLService.java
@@ -140,9 +140,11 @@ public class NLService extends NotificationListenerService {
     @Override
     public void onNotificationPosted(StatusBarNotification sbn) {
         Notification notification = sbn.getNotification();
+        String packageName = sbn.getPackageName();
 
         if((notification.priority < Notification.PRIORITY_DEFAULT) ||
-           ((notification.flags & Notification.FLAG_ONGOING_EVENT) != 0) ||
+           ((notification.flags & Notification.FLAG_ONGOING_EVENT) != 0
+            && !packageName.equals("com.google.android.apps.maps")) ||
            (NotificationCompat.getLocalOnly(notification)) ||
            (NotificationCompat.isGroupSummary(notification)))
             return;
@@ -151,7 +153,6 @@ public class NLService extends NotificationListenerService {
         String summary = notifParser.summary;
         String body = notifParser.body;
         int id = sbn.getId();
-        String packageName = sbn.getPackageName();
         String appIcon = iconFromPackage.get(packageName);
 
         String appName = "";


### PR DESCRIPTION
This patch whitelists `com.google.android.apps.maps` so the navigation notification can be displayed.

However, the notification strangely starts with "Quitter la navigation", which is the action button label:
![screenshot_20180719_234658](https://user-images.githubusercontent.com/840125/42972037-7e4e7ea4-8bae-11e8-8c8b-cbeddc6ebf0e.jpg)
