### PR TITLE
Allow ongoing from dialer

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/services/NLService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/NLService.java
@@ -34,6 +34,7 @@ import android.support.v4.app.NotificationCompat;
 
 import org.asteroidos.sync.utils.NotificationParser;
 
+import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -142,9 +143,10 @@ public class NLService extends NotificationListenerService {
         Notification notification = sbn.getNotification();
         String packageName = sbn.getPackageName();
 
+        String[] allowedOngoingApps = {"com.google.android.apps.maps", "com.android.dialer"};
         if((notification.priority < Notification.PRIORITY_DEFAULT) ||
            ((notification.flags & Notification.FLAG_ONGOING_EVENT) != 0
-            && !packageName.equals("com.google.android.apps.maps")) ||
+            && !Arrays.asList(allowedOngoingApps).contains(packageName)) ||
            (NotificationCompat.getLocalOnly(notification)) ||
            (NotificationCompat.isGroupSummary(notification)))
             return;

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 05 18:56:56 CET 2018
+#Sun Oct 07 14:32:21 EEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Without this patch (on LineageOS) one gets a notification on
the watch about a phone call only once the call has already been missed.

