### PR TITLE
Weather Location Sync

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission android:name="android.permission.ACCESS_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
@@ -162,13 +162,13 @@ public class PermissionsActivity extends MaterialIntroActivity {
             SlideFragment localizationFragment = new SlideFragmentBuilder()
                     .backgroundColor(R.color.colorintroslide3)
                     .buttonsColor(R.color.colorintroslide3button)
-                    .neededPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION})
+                    .neededPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION})
                     .image(R.drawable.introslide3icon)
                     .title(getString(R.string.intro_slide3_title))
                     .description(getString(R.string.intro_slide3_subtitle))
                     .build();
             boolean localizationFragmentShown = (ContextCompat.checkSelfPermission(this,
-                    Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED);
+                    Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED);
 
             NotificationsSlide notificationFragment = new NotificationsSlide();
             notificationFragment.setContext(this);

--- a/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
@@ -67,6 +67,8 @@ public class WeatherService implements BleDevice.ReadWriteListener {
     public WeatherService(Context ctx, BleDevice device) {
         mDevice = device;
         mCtx = ctx;
+
+        mSettings = mCtx.getSharedPreferences(PREFS_NAME, 0);
     }
 
     public void sync() {

--- a/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
@@ -24,10 +24,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Handler;
 import android.os.SystemClock;
 import android.util.Log;
 
 import com.idevicesinc.sweetblue.BleDevice;
+
+import org.asteroidos.sync.services.GPSTracker;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
@@ -54,6 +57,8 @@ public class WeatherService implements BleDevice.ReadWriteListener {
     public static final float PREFS_LONGITUDE_DEFAULT = (float) -74.006;
     public static final String PREFS_ZOOM = "zoom";
     public static final float PREFS_ZOOM_DEFAULT = (float) 7.0;
+    public static final String PREFS_SYNC_WEATHER = "syncWeather";
+    public static final boolean PREFS_SYNC_WEATHER_DEFAULT = false;
     public static final String WEATHER_SYNC_INTENT = "org.asteroidos.sync.WEATHER_SYNC_REQUEST_LISTENER";
 
     private BleDevice mDevice;
@@ -63,6 +68,10 @@ public class WeatherService implements BleDevice.ReadWriteListener {
     private WeatherSyncReqReceiver mSReceiver;
     private PendingIntent alarmPendingIntent;
     private AlarmManager alarmMgr;
+
+    private GPSTracker mGPS;
+    private Float mLatitude;
+    private Float mLongitude;
 
     public WeatherService(Context ctx, BleDevice device) {
         mDevice = device;
@@ -100,8 +109,50 @@ public class WeatherService implements BleDevice.ReadWriteListener {
     }
 
     private void updateWeather() {
-        float latitude = mSettings.getFloat(PREFS_LATITUDE, PREFS_LATITUDE_DEFAULT);
-        float longitude = mSettings.getFloat(PREFS_LONGITUDE, PREFS_LONGITUDE_DEFAULT);
+        if (mSettings.getBoolean(PREFS_SYNC_WEATHER, PREFS_SYNC_WEATHER_DEFAULT)) {
+            if (mGPS == null) {
+                mGPS = new GPSTracker(mCtx);
+            }
+            // Check if GPS enabled
+            mGPS.updateLocation();
+            if (mGPS.canGetLocation()) {
+                mLatitude = (float) mGPS.getLatitude();
+                mLongitude = (float) mGPS.getLongitude();
+                mGPS.gotLocation();
+                if(isNearNull(mLatitude) && isNearNull(mLongitude) ) {
+                    // We don't have a valid Location yet
+                    // Use the old location until we have a new one, recheck in 2 Minutes
+                    Handler handler = new Handler();
+                    handler.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            updateWeather();
+                        }
+                    }, 1000 * 60 * 2);
+                    return;
+                }
+            }
+            // } else {
+                // Can't get location.
+                // GPS or network is available, don't set new Location and reuse the old one.
+            // }
+        } else {
+            if (mGPS != null) {
+                mGPS.stopUsingGPS();
+                mGPS = null;
+            }
+            mLongitude = mSettings.getFloat(PREFS_LATITUDE, PREFS_LATITUDE_DEFAULT);
+            mLatitude = mSettings.getFloat(PREFS_LONGITUDE, PREFS_LONGITUDE_DEFAULT);
+        }
+        updateWeather(mLatitude, mLongitude);
+    }
+
+    private boolean isNearNull(float coord) {
+        return -0.000001f < coord && coord < 0.000001f;
+    }
+
+    private void updateWeather(float latitude, float longitude) {
+
         WeatherMap weatherMap = new WeatherMap(mCtx, owmApiKey);
         weatherMap.getLocationForecast(String.valueOf(latitude), String.valueOf(longitude), new ForecastCallback() {
             @Override

--- a/app/src/main/java/org/asteroidos/sync/services/GPSTracker.java
+++ b/app/src/main/java/org/asteroidos/sync/services/GPSTracker.java
@@ -1,0 +1,129 @@
+package org.asteroidos.sync.services;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.location.Criteria;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.util.Log;
+
+public class GPSTracker extends Service implements LocationListener {
+
+    private final Context mContext;
+
+    // Flag for GPS status
+    boolean mCanGetLocation;
+
+    double mLatitude; // Latitude
+    double mLongitude; // Longitude
+
+    // The minimum distance to change Updates in meters
+    private static final long MIN_DISTANCE_CHANGE_FOR_UPDATES = 100; // 100 meters
+
+    // The minimum time between updates in milliseconds
+    private static final long MIN_TIME_BW_UPDATES = 1000 * 60 * 10; // 10 minutes
+
+    // Declaring a Location Manager
+    protected LocationManager mLocationManager;
+
+    public GPSTracker(Context context) {
+        this.mContext = context;
+        mCanGetLocation = false;
+        updateLocation();
+    }
+
+    public void updateLocation() {
+        try {
+            mLocationManager = (LocationManager) mContext
+                    .getSystemService(LOCATION_SERVICE);
+
+            Criteria criteria = new Criteria();
+            criteria.setAccuracy(Criteria.ACCURACY_FINE);
+            criteria.setAltitudeRequired(false);
+            criteria.setBearingRequired(false);
+            criteria.setCostAllowed(true);
+            criteria.setPowerRequirement(Criteria.POWER_LOW);
+            String provider = mLocationManager.getBestProvider(criteria, true);
+            if(provider != null) {
+                mLocationManager.requestLocationUpdates(provider, MIN_TIME_BW_UPDATES, MIN_DISTANCE_CHANGE_FOR_UPDATES, this);
+                mCanGetLocation = true;
+            }
+        }
+        catch (SecurityException | NullPointerException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Stop using GPS listener
+     * Calling this function will stop using GPS in your app.
+     * */
+    public void stopUsingGPS(){
+        mCanGetLocation = false;
+        if(mLocationManager != null){
+            mLocationManager.removeUpdates(GPSTracker.this);
+        }
+    }
+
+
+    /**
+     * Function to get mLatitude
+     * */
+    public double getLatitude(){
+        // return mLatitude
+        return mLatitude;
+    }
+
+
+    /**
+     * Function to get mLongitude
+     * */
+    public double getLongitude(){
+        // return mLongitude
+        return mLongitude;
+    }
+
+    public void gotLocation() {
+        mCanGetLocation = false;
+    }
+
+    /**
+     * Function to check GPS/Wi-Fi enabled
+     * @return boolean
+     * */
+    public boolean canGetLocation() {
+        return this.mCanGetLocation;
+    }
+
+    @Override
+    public void onLocationChanged(Location location) {
+        mLatitude = location.getLatitude();
+        mLongitude = location.getLongitude();
+    }
+
+
+    @Override
+    public void onProviderDisabled(String provider) {
+    }
+
+
+    @Override
+    public void onProviderEnabled(String provider) {
+    }
+
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+    }
+
+
+    @Override
+    public IBinder onBind(Intent arg0) {
+        return null;
+    }
+}

--- a/app/src/main/res/layout/fragment_position_picker.xml
+++ b/app/src/main/res/layout/fragment_position_picker.xml
@@ -9,17 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <Button
-        android:id="@+id/positionPickerButton"
-        android:layout_width="wrap_content"
-        android:text="@string/use_this_area"
-        android:layout_height="50dp"
-        android:layout_centerHorizontal="true"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="10dp"
-        android:backgroundTint="@color/colorPrimary"
-        android:textColor="@android:color/white"/>
-
     <ImageView
         android:id="@+id/positionPickerIndicator"
         android:layout_width="40dp"
@@ -34,5 +23,36 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_centerInParent="true" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="0dp"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <CheckBox
+            android:id="@+id/autoLocationPickerButton"
+            style="@style/Widget.AppCompat.CompoundButton.CheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:background="@color/colorPrimary"
+            android:buttonTint="@android:color/white"
+            android:padding="5dp"
+            android:text="@string/synchronize_weather"
+            android:textAppearance="@style/TextAppearance.AppCompat.Widget.Button"
+            android:textColor="@android:color/white" />
+
+        <Button
+            android:id="@+id/positionPickerButton"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_marginBottom="10dp"
+            android:backgroundTint="@color/colorPrimary"
+            android:text="@string/use_this_area"
+            android:textColor="@android:color/white" />
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="downloaded">Downloaded</string>
     <string name="screenshot">Screenshot</string>
     <string name="synchronize_time">Synchronize time</string>
+    <string name="synchronize_weather">Locate weather automatically</string>
     <string name="notification_type_default">Default</string>
     <string name="notification_type_no_notif">No notification</string>
     <string name="notification_type_silent">Silent</string>


### PR DESCRIPTION
* Ask for FINE Location in PermissionsActivity
* Add user position on the Weather Map
* OptIn: Allow automatically getting weather based on user Location

If this option is enabled, the half hourly sync will not use the userdefined location but instead get the Location via GPS/Network.
This can be enabled in the Weather settings dialog.
If a user decides not to use this feature the GPS will only be used while on the Position Picker to show the current position.



This still requires a bit more of testing and code review, but it's working.