### PR TITLE
Changed NotificationChannel on the phone to "IMPORTANCE_LOW"

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -224,7 +224,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
         mNM = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel notificationChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, "Synchronization Service", NotificationManager.IMPORTANCE_DEFAULT);
+            NotificationChannel notificationChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, "Synchronization Service", NotificationManager.IMPORTANCE_LOW);
             notificationChannel.setDescription("Connection status");
             notificationChannel.setVibrationPattern(new long[]{0L});
             mNM.createNotificationChannel(notificationChannel);


### PR DESCRIPTION
Switched from IMPORTANCE_DEFAULT to IMPORTANCE_LOW, because since Android O DEFAULT is set as HIGH which results in notification sounds.

Google is aware of this [issue](https://issuetracker.google.com/issues/65108694), and they decided to close it as "Won't Fix (Infeasible)". 
