### PR TITLE
fixed #69

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/services/NLService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/NLService.java
@@ -146,7 +146,7 @@ public class NLService extends NotificationListenerService {
         Notification notification = sbn.getNotification();
         String packageName = sbn.getPackageName();
 
-        String[] allowedOngoingApps = {"com.google.android.apps.maps", "com.android.dialer"};
+        String[] allowedOngoingApps = {"com.google.android.apps.maps", "com.android.dialer", "com.google.android.dialer"};
         if((notification.priority < Notification.PRIORITY_DEFAULT) ||
            ((notification.flags & Notification.FLAG_ONGOING_EVENT) != 0
             && !Arrays.asList(allowedOngoingApps).contains(packageName)) ||


### PR DESCRIPTION
Call notifications on Pixel/Google branded devices and phones with bigger GAPPS packages are handled by `com.google.android.dialer` instead of `com.android.dialer` as an ongoing notification and have to be allowed in `String[ ] allowedOngoingApps`.