### PR TITLE
disabled badge on app icon for 'Synchronization Service'

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -231,6 +231,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
             NotificationChannel notificationChannel = new NotificationChannel(NOTIFICATION_CHANNEL_ID, "Synchronization Service", NotificationManager.IMPORTANCE_LOW);
             notificationChannel.setDescription("Connection status");
             notificationChannel.setVibrationPattern(new long[]{0L});
+            notificationChannel.setShowBadge(false);
             mNM.createNotificationChannel(notificationChannel);
         }
 


### PR DESCRIPTION
Since this is a persistent notification that shows the current connection status at all time the app icon should not have a badge indicating new important notifications.