### PR TITLE
improved standby exclusion request

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <uses-feature
         android:name="android.hardware.bluetooth_le"


### PR DESCRIPTION
As stated in the [doze standby documentation](https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases) 

We do this currently:
> An app can fire the `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS` intent to take the user directly to the **Battery Optimization**, where they can add the app.

This PR proposes to switch to the following concept, as it's easier for the user and more intuitive. The only downside is that we [would have to be whitelisted by Google for our use-case](https://developer.android.com/training/monitoring-device-state/doze-standby#whitelisting-cases) if we choose to publish on Google Play.

> An app holding the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission can trigger a system dialog to let the user add the app to the whitelist directly, without going to settings. The app fires a `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` Intent to trigger the dialog.
