### PR TITLE
Makes en-US and de-DE descriptions less redundant

### DIFF
--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -1,1 +1,9 @@
-Synchronisiere die Uhrzeit, Benachrichtigungen und mehr mit deiner AsteroidOS Smartwatch.
+AsteroidOSSync ist die offizielle Android App um deine AsteroidOS Smartwatch zu synchronisieren.
+
+• Zeit Sync
+• Wetter Sync
+• Benachrichtigungs Sync
+• "Finde meine Uhr"
+• Erzeuge Bildschirmfotos
+
+Um mehr über AsteroidOS zu lernen, besuche https://asteroidos.org/

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,1 +1,9 @@
-Synchronize the time, notifications and more with your AsteroidOS smartwatch.
+AsteroidOSSync is the official Android companion app for synchronizing your AsteroidOS smartwatch.
+
+• Time sync
+• Weather sync
+• Notification sync
+• "Find my watch"
+• Grab a screenshot
+
+To learn more about AsteroidOS, visit https://asteroidos.org/


### PR DESCRIPTION
As described in #98 F-Droid [changes the way short-descriptions are displayed](https://gitlab.com/fdroid/fdroidclient/merge_requests/855) 
This commit extends/changes the en-US and de-DE long descriptions to make them less redundant.