### PR TITLE
values-it/strings.xml:Fix crash when system language is Italian.

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -11,7 +11,7 @@
     <string name="connected">Connesso</string>
     <string name="connecting">Collegamento in corso…</string>
     <string name="connected_formatted">Connesso a %s</string>
-    <string name="connecting_formatted">Mi sto collegando con %s%</string>
+    <string name="connecting_formatted">Mi sto collegando con %s</string>
     <string name="connected_icon">Icona connessa</string>
     <string name="battery_info_icon">Icona stato batteria</string>
     <string name="screenshot_icon">Icona cattura schermo</string>


### PR DESCRIPTION
@dalz mentioned(https://github.com/AsteroidOS/AsteroidOSSync/issues/40) that the app is crashing when the language is set to Italian.

This patch should fix the issue again.