### PR TITLE
Screenshot store with MediaStore API and cleanup

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/MainActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/MainActivity.java
@@ -280,7 +280,7 @@ public class MainActivity extends AppCompatActivity implements DeviceListFragmen
             ab.setDisplayHomeAsUpEnabled(true);
     }
 
-    void handleSetLocalName(String name) {
+    private void handleSetLocalName(String name) {
         if(mDetailFragment != null)
             mDetailFragment.setLocalName(name);
     }

--- a/app/src/main/java/org/asteroidos/sync/MainActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/MainActivity.java
@@ -299,7 +299,7 @@ public class MainActivity extends AppCompatActivity implements DeviceListFragmen
         }
     }
 
-    void handleBatteryPercentage(int percentage) {
+    private void handleBatteryPercentage(int percentage) {
         if(mDetailFragment != null)
             mDetailFragment.setBatteryPercentage(percentage);
     }

--- a/app/src/main/java/org/asteroidos/sync/MainActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/MainActivity.java
@@ -285,7 +285,7 @@ public class MainActivity extends AppCompatActivity implements DeviceListFragmen
             mDetailFragment.setLocalName(name);
     }
 
-    void handleSetStatus(int status) {
+    private void handleSetStatus(int status) {
         if(mDetailFragment != null) {
             mDetailFragment.setStatus(status);
             if(status == SynchronizationService.STATUS_CONNECTED) {

--- a/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
@@ -99,7 +99,7 @@ public class PermissionsActivity extends MaterialIntroActivity {
         }
     }
 
-    public void startMainActivity() {
+    private void startMainActivity() {
         Intent intent = new Intent(this, MainActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME);
         startActivity(intent);

--- a/app/src/main/java/org/asteroidos/sync/ble/ScreenshotService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/ScreenshotService.java
@@ -112,7 +112,7 @@ public class ScreenshotService implements BleDevice.ReadWriteListener {
         @Override
         public void onEvent(ReadWriteEvent e) {
             if(e.isNotification() && e.charUuid().equals(screenshotContentCharac)) {
-                byte data[] = e.data();
+                byte[] data = e.data();
                 if(mFirstNotify) {
                     size = bytesToInt(data);
                     totalData = new byte[size];

--- a/app/src/main/java/org/asteroidos/sync/fragments/DeviceDetailFragment.java
+++ b/app/src/main/java/org/asteroidos/sync/fragments/DeviceDetailFragment.java
@@ -59,7 +59,7 @@ public class DeviceDetailFragment extends Fragment {
     private CheckBox mSilenceModeCheckBox;
     private CheckBox mCallStateServiceCheckBox;
 
-    FloatingActionButton mFab;
+    private FloatingActionButton mFab;
 
     private boolean mConnected = false;
 

--- a/app/src/main/java/org/asteroidos/sync/services/GPSTracker.java
+++ b/app/src/main/java/org/asteroidos/sync/services/GPSTracker.java
@@ -9,7 +9,6 @@ import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.util.Log;
 
 public class GPSTracker extends Service implements LocationListener {
 

--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -243,6 +243,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
         cfg.enableCrashResolver = true;
         cfg.bondFilter = new BondFilter();
         cfg.alwaysUseAutoConnect = true;
+        cfg.useLeTransportForBonding = true;
         if (BuildConfig.DEBUG)
             cfg.loggingEnabled = true;
         mBleMngr.setConfig(cfg);

--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -380,7 +380,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
         }
     }
 
-    private final class WatchesFilter implements BleManagerConfig.ScanFilter
+    private static final class WatchesFilter implements BleManagerConfig.ScanFilter
     {
         @Override
         public Please onEvent(ScanEvent e)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
 }
 


### PR DESCRIPTION
This fixes #106 but I don't have a device running API <= 9 with a functioning BLE stack. So this needs testing if it breaks storing images on Android 9 and below.