### PR TITLE
Add support for volume control.

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
@@ -128,7 +128,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
         public void onEvent(ReadWriteEvent e) {
             if(e.isNotification() && e.charUuid().equals(AsteroidUUIDS.MEDIA_COMMANDS_CHAR)) {
                 if (mMediaController != null) {
-                    byte data[] = e.data();
+                    byte[] data = e.data();
                     boolean isPoweramp = mSettings.getString(PREFS_MEDIA_CONTROLLER_PACKAGE, PREFS_MEDIA_CONTROLLER_PACKAGE_DEFAULT)
                             .equals(PowerampAPI.PACKAGE_NAME);
 
@@ -226,7 +226,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
          * @return the field value as a byte array
          */
         private byte[] getTextAsBytes(MediaMetadata metadata, String fieldName) {
-            byte [] result;
+            byte[] result;
 
             CharSequence text = metadata.getText(fieldName);
 

--- a/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
@@ -21,12 +21,16 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.database.ContentObserver;
+import android.media.AudioManager;
 import android.media.MediaMetadata;
 import android.media.session.MediaController;
 import android.media.session.MediaSession;
 import android.media.session.MediaSessionManager;
 import android.media.session.PlaybackState;
 import androidx.annotation.NonNull;
+
+import android.os.Handler;
 import android.util.Log;
 
 import com.idevicesinc.sweetblue.BleDevice;
@@ -38,7 +42,6 @@ import org.asteroidos.sync.utils.AsteroidUUIDS;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.UUID;
 
 @SuppressWarnings( "deprecation" ) // Before upgrading to SweetBlue 3.0, we don't have an alternative to the deprecated ReadWriteListener
 public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionManager.OnActiveSessionsChangedListener {
@@ -47,6 +50,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
     private static final byte MEDIA_COMMAND_NEXT     = 0x1;
     private static final byte MEDIA_COMMAND_PLAY     = 0x2;
     private static final byte MEDIA_COMMAND_PAUSE    = 0x3;
+    private static final byte MEDIA_COMMAND_VOLUME   = 0x4;
 
     public static final String PREFS_NAME = "MediaPreferences";
     public static final String PREFS_MEDIA_CONTROLLER_PACKAGE = "media_controller_package";
@@ -59,6 +63,8 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
     private MediaController mMediaController = null;
     private MediaSessionManager mMediaSessionManager;
 
+    private int mVolume;
+
     public MediaService(Context ctx, BleDevice device)
     {
         mDevice = device;
@@ -69,6 +75,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
 
     public void sync() {
         mDevice.enableNotify(AsteroidUUIDS.MEDIA_COMMANDS_CHAR, commandsListener);
+        mCtx.getContentResolver().registerContentObserver(android.provider.Settings.System.CONTENT_URI, true, mVolumeChangeObserver);
         try {
             mMediaSessionManager = (MediaSessionManager) mCtx.getSystemService(Context.MEDIA_SESSION_SERVICE);
             List<MediaController> controllers = mMediaSessionManager.getActiveSessions(new ComponentName(mCtx, NLService.class));
@@ -81,6 +88,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
 
     public void unsync() {
         mDevice.disableNotify(AsteroidUUIDS.MEDIA_COMMANDS_CHAR);
+        mCtx.getContentResolver().unregisterContentObserver(mVolumeChangeObserver);
 
         if(mMediaSessionManager != null)
             mMediaSessionManager.removeOnActiveSessionsChangedListener(this);
@@ -91,6 +99,29 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
             Log.d("MediaService", "MediaController removed");
         }
     }
+
+    private ContentObserver mVolumeChangeObserver = new ContentObserver(new Handler()) {
+        // The last value of volume send to the watch.
+        private int reportedVolume;
+
+        @Override
+        public void onChange(boolean selfChange) {
+            super.onChange(selfChange);
+            if (mMediaController != null && mMediaController.getPlaybackInfo() != null) {
+                int vol = (100 * mMediaController.getPlaybackInfo().getCurrentVolume()) / mMediaController.getPlaybackInfo().getMaxVolume();
+
+                if (reportedVolume != vol) {
+                    reportedVolume = vol;
+                    // Set real volume.
+                    mVolume = reportedVolume;
+
+                    byte[] data = new byte[1];
+                    data[0] = (byte) mVolume;
+                    mDevice.write(AsteroidUUIDS.MEDIA_VOLUME_CHAR, data, MediaService.this);
+                }
+            }
+        }
+    };
 
     private BleDevice.ReadWriteListener commandsListener = new BleDevice.ReadWriteListener() {
         @Override
@@ -132,6 +163,29 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
                                         .putExtra(PowerampAPI.COMMAND, PowerampAPI.Commands.PAUSE));
                             } else {
                                 mMediaController.getTransportControls().pause();
+                            }
+                             break;
+                        case MEDIA_COMMAND_VOLUME:
+                            if (mMediaController.getPlaybackInfo() != null) {
+                                if (data[1] != mVolume) {
+                                    int delta = Math.abs(mVolume - data[1]);
+                                    int deviceDelta = 100 / mMediaController.getPlaybackInfo().getMaxVolume();
+                                    // Change in volume is smaller than the device volume step (i.e. volume won't change)
+                                    // Increase or decrease the volume by one step anyway to improve UX.
+                                    if (delta < deviceDelta) {
+                                        if (data[1] > mVolume) {
+                                            mMediaController.adjustVolume(AudioManager.ADJUST_RAISE, AudioManager.FLAG_SHOW_UI);
+                                        } else if (data[1] < mVolume) {
+                                            mMediaController.adjustVolume(AudioManager.ADJUST_LOWER, AudioManager.FLAG_SHOW_UI);
+                                        }
+                                    } else {
+                                        // Convert volume range (0-100) to Android device range(0-?).
+                                        int volume = (int) (mMediaController.getPlaybackInfo().getMaxVolume() * (data[1] / 100.0));
+                                        mMediaController.setVolumeTo(volume, AudioManager.FLAG_SHOW_UI);
+                                    }
+                                    // Set theoretical volume.
+                                    mVolume = data[1];
+                                }
                             }
                              break;
                     }

--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -332,7 +332,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
                 public void onEvent(ReadWriteEvent e) {
                     try {
                         if (e.isNotification() && e.charUuid().equals(AsteroidUUIDS.BATTERY_UUID)) {
-                            byte data[] = e.data();
+                            byte[] data = e.data();
                             replyTo.send(Message.obtain(null, MSG_SET_BATTERY_PERCENTAGE, data[0], 0));
                         }
                     } catch(RemoteException | NullPointerException ignored) {}


### PR DESCRIPTION
tbh, I am not really happy with the code. Please let me know if you have suggestions to make it easier to understand.

On Android it seems (in my case at least), we have a low volume range (0-15), while from btsyncd we get a range of (0-100). Mapping this is easy. However, depending on the increment/decrement value in the asteroid-music app, nothing may happen if the value is too small. To workaround this, just increment/decrement the value if it noticed a change in volume. Because under no circumstance we want nothing to happen when the user presses the increment/decrement button in the asteroid-music app.

~Another problem arises when the volume changes rapidly. We shouldn't report back a value to the watch, as that would confuse the receiving part. A situation illustrated below may arise.~
~This flow of data should explain the issue:~
- ~Press increment button repeatedly~
- ~10 is received(sets volume)~
- ~20 is received(sets volume)~
- ~30 is received~
- ~volume change observed a change in volume! (send value 30 to watch)~
- ~40 is received~
- ~50 is received~
- ~value 30 is received by watch (sets volume to 30)~
- ~40 is received~

~So this will end up as, the user wants to increase the volume x amount of times, this will result in a volume up mostly, while sometimes it also decreases the volume.~
^ No longer relevant, handled by `asteroid-music` app.

I hope this explains some of the motivations behind this code :wink: 