### PR TITLE
Android 11 (SDK 30) fixes and general improvements/updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.13'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation 'com.google.android.material:material:1.2.0'
     implementation 'github.vatsal.easyweather:library:1.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.osmdroid:osmdroid-android:6.1.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 30
+    buildToolsVersion '30.0.1'
 
     defaultConfig {
         applicationId "org.asteroidos.sync"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 18
         versionName "0.18"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.READ_CALL_LOG"/>
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
 
     <uses-feature
         android:name="android.hardware.bluetooth_le"

--- a/app/src/main/java/org/asteroidos/sync/adapters/AppInfoAdapter.java
+++ b/app/src/main/java/org/asteroidos/sync/adapters/AppInfoAdapter.java
@@ -3,7 +3,9 @@ package org.asteroidos.sync.adapters;
 // copied from https://github.com/jensstein/oandbackup, used under MIT license
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
+
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -25,53 +27,45 @@ import org.asteroidos.sync.R;
 import java.util.ArrayList;
 import java.util.List;
 
-public class AppInfoAdapter extends ArrayAdapter<AppInfo>
-{
+public class AppInfoAdapter extends ArrayAdapter<AppInfo> {
     private final static String TAG = AppInfoAdapter.class.getSimpleName();
 
     private Context context;
     private ArrayList<AppInfo> items;
     private int iconSize, layout;
 
-    public AppInfoAdapter(Context context, int layout, ArrayList<AppInfo> items)
-    {
+    public AppInfoAdapter(Context context, int layout, ArrayList<AppInfo> items) {
         super(context, layout, items);
         this.context = context;
         this.items = new ArrayList<>(items);
         this.layout = layout;
 
-        try
-        {
+        try {
             DisplayMetrics metrics = new DisplayMetrics();
             ((android.app.Activity) context).getWindowManager().getDefaultDisplay().getMetrics(metrics);
             iconSize = 32 * (int) metrics.density;
-        }
-        catch(ClassCastException e)
-        {
+        } catch (ClassCastException e) {
             iconSize = 32;
         }
     }
-    public void add(AppInfo appInfo)
-    {
+
+    public void add(AppInfo appInfo) {
         items.add(appInfo);
     }
 
-    public AppInfo getItem(int pos)
-    {
+    public AppInfo getItem(int pos) {
         return items.get(pos);
     }
-    public int getCount()
-    {
+
+    public int getCount() {
         return items.size();
     }
 
     @NonNull
     @Override
-    public View getView(int pos, View convertView, @NonNull ViewGroup parent)
-    {
+    public View getView(int pos, View convertView, @NonNull ViewGroup parent) {
         ViewHolder viewHolder;
-        if(convertView == null)
-        {
+        if (convertView == null) {
             LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             assert inflater != null;
             convertView = inflater.inflate(layout, parent, false);
@@ -80,24 +74,18 @@ public class AppInfoAdapter extends ArrayAdapter<AppInfo>
             viewHolder.icon = convertView.findViewById(R.id.icon);
             viewHolder.spinner = convertView.findViewById(R.id.notification_spinner);
             convertView.setTag(viewHolder);
-        }
-        else
-        {
+        } else {
             viewHolder = (ViewHolder) convertView.getTag();
         }
         AppInfo appInfo = getItem(pos);
-        if(appInfo != null)
-        {
-            if(appInfo.icon != null)
-            {
+        if (appInfo != null) {
+            if (appInfo.icon != null) {
                 viewHolder.icon.setVisibility(View.VISIBLE); // to cancel View.GONE if it was set
                 viewHolder.icon.setImageBitmap(appInfo.icon);
                 LayoutParams lp = (LayoutParams) viewHolder.icon.getLayoutParams();
                 lp.height = lp.width = iconSize;
                 viewHolder.icon.setLayoutParams(lp);
-            }
-            else
-            {
+            } else {
                 viewHolder.icon.setVisibility(View.GONE);
             }
             viewHolder.label.setText(appInfo.getLabel());
@@ -129,64 +117,63 @@ public class AppInfoAdapter extends ArrayAdapter<AppInfo>
         }
         return convertView;
     }
-    abstract class MyOnItemSelectedListener implements AdapterView.OnItemSelectedListener {
-        String packageName;
-        MyOnItemSelectedListener(String packageName) {
-            this.packageName = packageName;
-        }
+
+    @NonNull
+    @Override
+    public Filter getFilter() {
+        return new SeenPackagesFilter(NotificationPreferences.seenPackageNames(context));
     }
-    private static class ViewHolder
-    {
+
+    public void restoreFilter() {
+        getFilter().filter(null);
+    }
+
+    private static class ViewHolder {
         TextView label;
         ImageView icon;
         Spinner spinner;
     }
-    @NonNull
-    @Override
-    public Filter getFilter()
-    {
-        return new SeenPackagesFilter(NotificationPreferences.seenPackageNames(context));
+
+    abstract class MyOnItemSelectedListener implements AdapterView.OnItemSelectedListener {
+        String packageName;
+
+        MyOnItemSelectedListener(String packageName) {
+            this.packageName = packageName;
+        }
     }
-    public void restoreFilter()
-    {
-        getFilter().filter(null);
-    }
-    private class SeenPackagesFilter extends Filter
-    {
+
+    private class SeenPackagesFilter extends Filter {
 
         private List<String> seenPackages;
+
         private SeenPackagesFilter(List<String> seenPackages) {
             this.seenPackages = seenPackages;
         }
+
         @Override
-        protected FilterResults performFiltering(CharSequence ignored)
-        {
+        protected FilterResults performFiltering(CharSequence ignored) {
             FilterResults results = new FilterResults();
             ArrayList<AppInfo> newValues = new ArrayList<>();
-            for(AppInfo value : items)
-            {
+            for (AppInfo value : items) {
                 String packageName = value.getPackageName().toLowerCase();
-                if(seenPackages.contains(packageName))
+                if (seenPackages.contains(packageName))
                     newValues.add(value);
             }
             results.values = newValues;
             results.count = newValues.size();
             return results;
         }
+
         @Override
         @SuppressWarnings("unchecked")
-        protected void publishResults(CharSequence constraint, FilterResults results)
-        {
-            if(results.count > 0)
-            {
+        protected void publishResults(CharSequence constraint, FilterResults results) {
+            if (results.count > 0) {
                 items.clear();
-                for(AppInfo value : (ArrayList<AppInfo>) results.values)
+                for (AppInfo value : (ArrayList<AppInfo>) results.values)
                     add(value);
 
                 notifyDataSetChanged();
-            }
-            else
-            {
+            } else {
                 items.clear();
                 notifyDataSetInvalidated();
             }


### PR DESCRIPTION
- Addresses the package visibility issue mentioned in #114 by adding the [`QUERY_ALL_PACKAGES`](https://developer.android.com/reference/android/Manifest.permission#QUERY_ALL_PACKAGES) permission
- Reformats the `AppInfoAdapter` to be more consistent and improve readability
- Updates `AppCompat` and `Material Design`
- Increases the SDK level to 30 (Android 11)