### PR TITLE
patch to increase modularity

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/MediaService.java
@@ -34,6 +34,7 @@ import com.maxmpz.poweramp.player.PowerampAPI;
 import com.maxmpz.poweramp.player.PowerampAPIHelper;
 
 import org.asteroidos.sync.services.NLService;
+import org.asteroidos.sync.utils.AsteroidUUIDS;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -41,11 +42,6 @@ import java.util.UUID;
 
 @SuppressWarnings( "deprecation" ) // Before upgrading to SweetBlue 3.0, we don't have an alternative to the deprecated ReadWriteListener
 public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionManager.OnActiveSessionsChangedListener {
-    private static final UUID mediaTitleCharac    = UUID.fromString("00007001-0000-0000-0000-00A57E401D05");
-    private static final UUID mediaAlbumCharac    = UUID.fromString("00007002-0000-0000-0000-00A57E401D05");
-    private static final UUID mediaArtistCharac   = UUID.fromString("00007003-0000-0000-0000-00A57E401D05");
-    private static final UUID mediaPlayingCharac  = UUID.fromString("00007004-0000-0000-0000-00A57E401D05");
-    private static final UUID mediaCommandsCharac = UUID.fromString("00007005-0000-0000-0000-00A57E401D05");
 
     private static final byte MEDIA_COMMAND_PREVIOUS = 0x0;
     private static final byte MEDIA_COMMAND_NEXT     = 0x1;
@@ -72,7 +68,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
     }
 
     public void sync() {
-        mDevice.enableNotify(mediaCommandsCharac, commandsListener);
+        mDevice.enableNotify(AsteroidUUIDS.MEDIA_COMMANDS_CHAR, commandsListener);
         try {
             mMediaSessionManager = (MediaSessionManager) mCtx.getSystemService(Context.MEDIA_SESSION_SERVICE);
             List<MediaController> controllers = mMediaSessionManager.getActiveSessions(new ComponentName(mCtx, NLService.class));
@@ -84,7 +80,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
     }
 
     public void unsync() {
-        mDevice.disableNotify(mediaCommandsCharac);
+        mDevice.disableNotify(AsteroidUUIDS.MEDIA_COMMANDS_CHAR);
 
         if(mMediaSessionManager != null)
             mMediaSessionManager.removeOnActiveSessionsChangedListener(this);
@@ -99,7 +95,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
     private BleDevice.ReadWriteListener commandsListener = new BleDevice.ReadWriteListener() {
         @Override
         public void onEvent(ReadWriteEvent e) {
-            if(e.isNotification() && e.charUuid().equals(mediaCommandsCharac)) {
+            if(e.isNotification() && e.charUuid().equals(AsteroidUUIDS.MEDIA_COMMANDS_CHAR)) {
                 if (mMediaController != null) {
                     byte data[] = e.data();
                     boolean isPoweramp = mSettings.getString(PREFS_MEDIA_CONTROLLER_PACKAGE, PREFS_MEDIA_CONTROLLER_PACKAGE_DEFAULT)
@@ -194,15 +190,15 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
             super.onMetadataChanged(metadata);
 
             if (metadata != null) {
-                mDevice.write(mediaArtistCharac,
+                mDevice.write(AsteroidUUIDS.MEDIA_ARTIST_CHAR,
                         getTextAsBytes(metadata, MediaMetadata.METADATA_KEY_ARTIST),
                         MediaService.this);
 
-                mDevice.write(mediaAlbumCharac,
+                mDevice.write(AsteroidUUIDS.MEDIA_ALBUM_CHAR,
                         getTextAsBytes(metadata, MediaMetadata.METADATA_KEY_ALBUM),
                         MediaService.this);
 
-                mDevice.write(mediaTitleCharac,
+                mDevice.write(AsteroidUUIDS.MEDIA_TITLE_CHAR,
                         getTextAsBytes(metadata, MediaMetadata.METADATA_KEY_TITLE),
                         MediaService.this);
             }
@@ -213,7 +209,7 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
             super.onPlaybackStateChanged(state);
             byte[] data = new byte[1];
             data[0] = (byte)(state.getState() == PlaybackState.STATE_PLAYING ?  1 : 0);
-            mDevice.write(mediaPlayingCharac, data, MediaService.this);
+            mDevice.write(AsteroidUUIDS.MEDIA_PLAYING_CHAR, data, MediaService.this);
         }
 
         @Override
@@ -250,9 +246,9 @@ public class MediaService implements BleDevice.ReadWriteListener,  MediaSessionM
             }
         } else {
             byte[] data = new byte[]{0};
-            mDevice.write(mediaArtistCharac, data, MediaService.this);
-            mDevice.write(mediaAlbumCharac, data, MediaService.this);
-            mDevice.write(mediaTitleCharac, data, MediaService.this);
+            mDevice.write(AsteroidUUIDS.MEDIA_ARTIST_CHAR, data, MediaService.this);
+            mDevice.write(AsteroidUUIDS.MEDIA_ALBUM_CHAR, data, MediaService.this);
+            mDevice.write(AsteroidUUIDS.MEDIA_TITLE_CHAR, data, MediaService.this);
         }
     }
 }

--- a/app/src/main/java/org/asteroidos/sync/ble/NotificationService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/NotificationService.java
@@ -26,8 +26,8 @@ import android.util.Log;
 import com.idevicesinc.sweetblue.BleDevice;
 
 import org.asteroidos.sync.NotificationPreferences;
+import org.asteroidos.sync.dataobjects.Notification;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -107,32 +107,21 @@ public class NotificationService implements BleDevice.ReadWriteListener {
                 if(intent.hasExtra("vibration"))
                     vibration = intent.getStringExtra("vibration");
 
-                String xmlRequest = "<insert><id>" + id + "</id>";
-                if(!packageName.isEmpty())
-                    xmlRequest += "<pn>" + packageName + "</pn>";
-                if(!vibration.isEmpty())
-                    xmlRequest += "<vb>" + vibration + "</vb>";
-                if(!appName.isEmpty())
-                    xmlRequest += "<an>" + appName + "</an>";
-                if(!appIcon.isEmpty())
-                    xmlRequest += "<ai>" + appIcon + "</ai>";
-                if(!summary.isEmpty())
-                    xmlRequest += "<su>" + summary + "</su>";
-                if(!body.isEmpty())
-                    xmlRequest += "<bo>" + body + "</bo>";
-                xmlRequest += "</insert>";
+                Notification notification = new Notification(
+                        Notification.MsgType.POSTED,
+                        packageName,
+                        id,
+                        appName,
+                        appIcon,
+                        summary,
+                        body,
+                        vibration);
 
-                byte[] data = xmlRequest.getBytes(StandardCharsets.UTF_8);
-                mDevice.write(notificationUpdateCharac, data, NotificationService.this);
+                mDevice.write(notificationUpdateCharac, notification.toBytes(), NotificationService.this);
             } else if (Objects.equals(event, "removed")) {
                 int id = intent.getIntExtra("id", 0);
 
-                String xmlRequest = "<removed>" +
-                        "<id>" + id + "</id>" +
-                        "</removed>";
-
-                byte[] data = xmlRequest.getBytes(StandardCharsets.UTF_8);
-                mDevice.write(notificationUpdateCharac, data, NotificationService.this);
+                mDevice.write(notificationUpdateCharac, new Notification(Notification.MsgType.REMOVED, id).toBytes(), NotificationService.this);
             }
         }
     }

--- a/app/src/main/java/org/asteroidos/sync/ble/NotificationService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/NotificationService.java
@@ -27,14 +27,12 @@ import com.idevicesinc.sweetblue.BleDevice;
 
 import org.asteroidos.sync.NotificationPreferences;
 import org.asteroidos.sync.dataobjects.Notification;
+import org.asteroidos.sync.utils.AsteroidUUIDS;
 
 import java.util.Objects;
-import java.util.UUID;
 
 @SuppressWarnings( "deprecation" ) // Before upgrading to SweetBlue 3.0, we don't have an alternative to the deprecated ReadWriteListener
 public class NotificationService implements BleDevice.ReadWriteListener {
-    private static final UUID notificationUpdateCharac   = UUID.fromString("00009001-0000-0000-0000-00a57e401d05");
-    private static final UUID notificationFeedbackCharac = UUID.fromString("00009002-0000-0000-0000-00a57e401d05");
 
     private Context mCtx;
     private BleDevice mDevice;
@@ -48,7 +46,7 @@ public class NotificationService implements BleDevice.ReadWriteListener {
     }
 
     public void sync() {
-        mDevice.enableNotify(notificationFeedbackCharac);
+        mDevice.enableNotify(AsteroidUUIDS.NOTIFICATION_FEEDBACK_CHAR);
 
         mNReceiver = new NotificationReceiver();
         IntentFilter filter = new IntentFilter();
@@ -61,7 +59,7 @@ public class NotificationService implements BleDevice.ReadWriteListener {
     }
 
     public void unsync() {
-        mDevice.disableNotify(notificationFeedbackCharac);
+        mDevice.disableNotify(AsteroidUUIDS.NOTIFICATION_FEEDBACK_CHAR);
         try {
             mCtx.unregisterReceiver(mNReceiver);
         } catch (IllegalArgumentException ignored) {}
@@ -117,11 +115,11 @@ public class NotificationService implements BleDevice.ReadWriteListener {
                         body,
                         vibration);
 
-                mDevice.write(notificationUpdateCharac, notification.toBytes(), NotificationService.this);
+                mDevice.write(AsteroidUUIDS.NOTIFICATION_UPDATE_CHAR, notification.toBytes(), NotificationService.this);
             } else if (Objects.equals(event, "removed")) {
                 int id = intent.getIntExtra("id", 0);
 
-                mDevice.write(notificationUpdateCharac, new Notification(Notification.MsgType.REMOVED, id).toBytes(), NotificationService.this);
+                mDevice.write(AsteroidUUIDS.NOTIFICATION_UPDATE_CHAR, new Notification(Notification.MsgType.REMOVED, id).toBytes(), NotificationService.this);
             }
         }
     }

--- a/app/src/main/java/org/asteroidos/sync/ble/ScreenshotService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/ScreenshotService.java
@@ -40,6 +40,7 @@ import android.util.Log;
 import com.idevicesinc.sweetblue.BleDevice;
 
 import org.asteroidos.sync.R;
+import org.asteroidos.sync.utils.AsteroidUUIDS;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -57,9 +58,6 @@ import java.util.concurrent.TimeUnit;
 public class ScreenshotService implements BleDevice.ReadWriteListener {
     private static final String NOTIFICATION_CHANNEL_ID = "screenshotservice_channel_id_01";
     private int NOTIFICATION = 2726;
-
-    private static final UUID screenshotRequestCharac = UUID.fromString("00006001-0000-0000-0000-00a57e401d05");
-    private static final UUID screenshotContentCharac = UUID.fromString("00006002-0000-0000-0000-00a57e401d05");
 
     private Context mCtx;
     private BleDevice mDevice;
@@ -86,7 +84,7 @@ public class ScreenshotService implements BleDevice.ReadWriteListener {
     }
 
     public void sync() {
-        mDevice.enableNotify(screenshotContentCharac, contentListener);
+        mDevice.enableNotify(AsteroidUUIDS.SCREENSHOT_CONTENT, contentListener);
 
         mSReceiver = new ScreenshotReqReceiver();
         IntentFilter filter = new IntentFilter();
@@ -97,7 +95,7 @@ public class ScreenshotService implements BleDevice.ReadWriteListener {
     }
 
     public void unsync() {
-        mDevice.disableNotify(screenshotContentCharac);
+        mDevice.disableNotify(AsteroidUUIDS.SCREENSHOT_CONTENT);
         try {
             mCtx.unregisterReceiver(mSReceiver);
         } catch (IllegalArgumentException ignored) {}
@@ -120,7 +118,7 @@ public class ScreenshotService implements BleDevice.ReadWriteListener {
 
         @Override
         public void onEvent(ReadWriteEvent e) {
-            if(e.isNotification() && e.charUuid().equals(screenshotContentCharac)) {
+            if(e.isNotification() && e.charUuid().equals(AsteroidUUIDS.SCREENSHOT_CONTENT)) {
                 byte[] data = e.data();
                 if(mFirstNotify) {
                     size = bytesToInt(data);
@@ -252,7 +250,7 @@ public class ScreenshotService implements BleDevice.ReadWriteListener {
                 mDownloading = true;
                 byte[] data = new byte[1];
                 data[0] = 0x0;
-                mDevice.write(screenshotRequestCharac, data, ScreenshotService.this);
+                mDevice.write(AsteroidUUIDS.SCREENSHOT_REQUEST, data, ScreenshotService.this);
             }
         }
     }

--- a/app/src/main/java/org/asteroidos/sync/ble/TimeService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/TimeService.java
@@ -30,12 +30,13 @@ import android.util.Log;
 
 import com.idevicesinc.sweetblue.BleDevice;
 
+import org.asteroidos.sync.utils.AsteroidUUIDS;
+
 import java.util.Calendar;
 import java.util.UUID;
 
 @SuppressWarnings( "deprecation" ) // Before upgrading to SweetBlue 3.0, we don't have an alternative to the deprecated ReadWriteListener
 public class TimeService implements BleDevice.ReadWriteListener, SharedPreferences.OnSharedPreferenceChangeListener {
-    private static final UUID timeSetCharac = UUID.fromString("00005001-0000-0000-0000-00a57e401d05");
 
     public static final String PREFS_NAME = "TimePreference";
     public static final String PREFS_SYNC_TIME = "syncTime";
@@ -100,7 +101,7 @@ public class TimeService implements BleDevice.ReadWriteListener, SharedPreferenc
             data[3] = (byte)(c.get(Calendar.HOUR_OF_DAY));
             data[4] = (byte)(c.get(Calendar.MINUTE));
             data[5] = (byte)(c.get(Calendar.SECOND));
-            mDevice.write(timeSetCharac, data, TimeService.this);
+            mDevice.write(AsteroidUUIDS.TIME_SET_CHAR, data, TimeService.this);
         }
     }
 

--- a/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
+++ b/app/src/main/java/org/asteroidos/sync/ble/WeatherService.java
@@ -32,6 +32,7 @@ import android.util.Log;
 import com.idevicesinc.sweetblue.BleDevice;
 
 import org.asteroidos.sync.services.GPSTracker;
+import org.asteroidos.sync.utils.AsteroidUUIDS;
 import org.osmdroid.config.Configuration;
 
 import java.nio.charset.StandardCharsets;
@@ -45,10 +46,6 @@ import github.vatsal.easyweather.retrofit.models.List;
 
 @SuppressWarnings( "deprecation" ) // Before upgrading to SweetBlue 3.0, we don't have an alternative to the deprecated ReadWriteListener
 public class WeatherService implements BleDevice.ReadWriteListener {
-    private static final UUID weatherCityCharac     = UUID.fromString("00008001-0000-0000-0000-00a57e401d05");
-    private static final UUID weatherIdsCharac      = UUID.fromString("00008002-0000-0000-0000-00a57e401d05");
-    private static final UUID weatherMinTempsCharac = UUID.fromString("00008003-0000-0000-0000-00a57e401d05");
-    private static final UUID weatherMaxTempsCharac = UUID.fromString("00008004-0000-0000-0000-00a57e401d05");
 
     private static final String owmApiKey = "ffcb5a7ed134aac3d095fa628bc46c65";
 
@@ -207,10 +204,10 @@ public class WeatherService implements BleDevice.ReadWriteListener {
                     }
                 } catch(java.lang.ArrayIndexOutOfBoundsException ignored) {}
 
-                mDevice.write(weatherCityCharac, city, WeatherService.this);
-                mDevice.write(weatherIdsCharac, ids, WeatherService.this);
-                mDevice.write(weatherMaxTempsCharac, maxTemps, WeatherService.this);
-                mDevice.write(weatherMinTempsCharac, minTemps, WeatherService.this);
+                mDevice.write(AsteroidUUIDS.WEATHER_CITY_CHAR, city, WeatherService.this);
+                mDevice.write(AsteroidUUIDS.WEATHER_IDS_CHAR, ids, WeatherService.this);
+                mDevice.write(AsteroidUUIDS.WEATHER_MAX_TEMPS_CHAR, maxTemps, WeatherService.this);
+                mDevice.write(AsteroidUUIDS.WEATHER_MIN_TEMPS_CHAR, minTemps, WeatherService.this);
             }
 
             @Override public void failure(String message) {

--- a/app/src/main/java/org/asteroidos/sync/dataobjects/Notification.java
+++ b/app/src/main/java/org/asteroidos/sync/dataobjects/Notification.java
@@ -1,0 +1,66 @@
+package org.asteroidos.sync.dataobjects;
+
+import java.nio.charset.StandardCharsets;
+
+public class Notification {
+    String packageName, appName, appIcon, summary, body, vibration = "";
+    MsgType msgType = null;
+    int id = 0;
+
+    public Notification(MsgType msgType, String packageName, int id, String appName, String appIcon, String summary, String body, String vibration) {
+        this.msgType = msgType;
+        this.packageName = packageName;
+        this.id = id;
+        this.appName = appName;
+        this.appIcon = appIcon;
+        this.summary = summary;
+        this.body = body;
+        this.vibration = vibration;
+    }
+
+    public Notification(MsgType msgType, int id) {
+        this.msgType = msgType;
+        this.id = id;
+    }
+
+    /***
+     * @return XML serialized {@link Notification}
+     */
+    public final String toXML() {
+        String xmlRequest = "";
+
+        if (msgType == MsgType.POSTED) {
+            xmlRequest = "<insert><id>" + id + "</id>";
+            if (!packageName.isEmpty())
+                xmlRequest += "<pn>" + packageName + "</pn>";
+            if (!vibration.isEmpty())
+                xmlRequest += "<vb>" + vibration + "</vb>";
+            if (!appName.isEmpty())
+                xmlRequest += "<an>" + appName + "</an>";
+            if (!appIcon.isEmpty())
+                xmlRequest += "<ai>" + appIcon + "</ai>";
+            if (!summary.isEmpty())
+                xmlRequest += "<su>" + summary + "</su>";
+            if (!body.isEmpty())
+                xmlRequest += "<bo>" + body + "</bo>";
+            xmlRequest += "</insert>";
+        } else if (msgType == MsgType.REMOVED) {
+            xmlRequest = "<removed>" +
+                    "<id>" + id + "</id>" +
+                    "</removed>";
+        }
+
+        return xmlRequest;
+    }
+
+    /***
+     * @return Returns {@link Notification#toXML()} as byte[] for BLE transmission
+     */
+    public final byte[] toBytes() {
+        return this.toXML().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public enum MsgType {
+        POSTED, REMOVED
+    }
+}

--- a/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
+++ b/app/src/main/java/org/asteroidos/sync/services/SynchronizationService.java
@@ -41,7 +41,6 @@ import com.idevicesinc.sweetblue.BleManagerConfig;
 import com.idevicesinc.sweetblue.BleNodeConfig;
 import com.idevicesinc.sweetblue.BleTask;
 import com.idevicesinc.sweetblue.utils.Interval;
-import com.idevicesinc.sweetblue.utils.Uuids;
 
 import org.asteroidos.sync.BuildConfig;
 import org.asteroidos.sync.MainActivity;
@@ -52,8 +51,7 @@ import org.asteroidos.sync.ble.ScreenshotService;
 import org.asteroidos.sync.ble.SilentModeService;
 import org.asteroidos.sync.ble.TimeService;
 import org.asteroidos.sync.ble.WeatherService;
-
-import java.util.UUID;
+import org.asteroidos.sync.utils.AsteroidUUIDS;
 
 import static com.idevicesinc.sweetblue.BleManager.get;
 
@@ -121,7 +119,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
     void handleReqBattery() {
         if(mDevice == null) return;
         if(mState == STATUS_DISCONNECTED) return;
-        mDevice.read(Uuids.BATTERY_LEVEL, new BleDevice.ReadWriteListener()
+        mDevice.read(AsteroidUUIDS.BATTERY_UUID, new BleDevice.ReadWriteListener()
         {
             @Override public void onEvent(ReadWriteEvent result)
             {
@@ -175,7 +173,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
 
                 replyTo.send(Message.obtain(null, MSG_SET_STATUS, mState, 0));
 
-                mDevice.read(Uuids.BATTERY_LEVEL, new BleDevice.ReadWriteListener()
+                mDevice.read(AsteroidUUIDS.BATTERY_UUID, new BleDevice.ReadWriteListener()
                 {
                     @Override public void onEvent(ReadWriteEvent result)
                     {
@@ -329,11 +327,11 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
             } catch (RemoteException | NullPointerException ignored) {}
             mDevice.setMtu(256);
 
-            event.device().enableNotify(Uuids.BATTERY_LEVEL, new BleDevice.ReadWriteListener() {
+            event.device().enableNotify(AsteroidUUIDS.BATTERY_UUID, new BleDevice.ReadWriteListener() {
                 @Override
                 public void onEvent(ReadWriteEvent e) {
                     try {
-                        if (e.isNotification() && e.charUuid().equals(Uuids.BATTERY_LEVEL)) {
+                        if (e.isNotification() && e.charUuid().equals(AsteroidUUIDS.BATTERY_UUID)) {
                             byte data[] = e.data();
                             replyTo.send(Message.obtain(null, MSG_SET_BATTERY_PERCENTAGE, data[0], 0));
                         }
@@ -386,7 +384,7 @@ public class SynchronizationService extends Service implements BleDevice.StateLi
         @Override
         public Please onEvent(ScanEvent e)
         {
-            return Please.acknowledgeIf(e.advertisedServices().contains(UUID.fromString("00000000-0000-0000-0000-00a57e401d05")));
+            return Please.acknowledgeIf(e.advertisedServices().contains(AsteroidUUIDS.SERVICE_UUID));
         }
     }
 

--- a/app/src/main/java/org/asteroidos/sync/utils/AsteroidUUIDS.java
+++ b/app/src/main/java/org/asteroidos/sync/utils/AsteroidUUIDS.java
@@ -1,0 +1,39 @@
+/* AsteroidOS UUID collection for ble characteristics and watch filtering */
+package org.asteroidos.sync.utils;
+
+import java.util.UUID;
+
+public class AsteroidUUIDS {
+    // AsteroidOS Service Watch Filter UUID
+    public static final UUID SERVICE_UUID               = UUID.fromString("00000000-0000-0000-0000-00A57E401D05");
+
+    // Battery level
+    public static final UUID BATTERY_SERVICE_UUID       = UUID.fromString("0000180F-0000-1000-8000-00805F9B34FB");
+    public static final UUID BATTERY_UUID               = UUID.fromString("00002A19-0000-1000-8000-00805F9B34FB");
+
+    // Time
+    public static final UUID TIME_SET_CHAR              = UUID.fromString("00005001-0000-0000-0000-00A57E401D05");
+
+    // ScreenshotService
+    public static final UUID SCREENSHOT_REQUEST         = UUID.fromString("00006001-0000-0000-0000-00A57E401D05");
+    public static final UUID SCREENSHOT_CONTENT         = UUID.fromString("00006002-0000-0000-0000-00A57E401D05");
+
+    // MediaService
+    public static final UUID MEDIA_TITLE_CHAR           = UUID.fromString("00007001-0000-0000-0000-00A57E401D05");
+    public static final UUID MEDIA_ALBUM_CHAR           = UUID.fromString("00007002-0000-0000-0000-00A57E401D05");
+    public static final UUID MEDIA_ARTIST_CHAR          = UUID.fromString("00007003-0000-0000-0000-00A57E401D05");
+    public static final UUID MEDIA_PLAYING_CHAR         = UUID.fromString("00007004-0000-0000-0000-00A57E401D05");
+    public static final UUID MEDIA_COMMANDS_CHAR        = UUID.fromString("00007005-0000-0000-0000-00A57E401D05");
+    public static final UUID MEDIA_VOLUME_CHAR          = UUID.fromString("00007006-0000-0000-0000-00A57E401D05");
+
+    // WeatherService
+    public static final UUID WEATHER_CITY_CHAR          = UUID.fromString("00008001-0000-0000-0000-00A57E401D05");
+    public static final UUID WEATHER_IDS_CHAR           = UUID.fromString("00008002-0000-0000-0000-00A57E401D05");
+    public static final UUID WEATHER_MIN_TEMPS_CHAR     = UUID.fromString("00008003-0000-0000-0000-00A57E401D05");
+    public static final UUID WEATHER_MAX_TEMPS_CHAR     = UUID.fromString("00008004-0000-0000-0000-00A57E401D05");
+
+    // Notification Service
+    public static final UUID NOTIFICATION_SERVICE_UUID  = UUID.fromString("00009071-0000-0000-0000-00A57E401D05");
+    public static final UUID NOTIFICATION_UPDATE_CHAR   = UUID.fromString("00009001-0000-0000-0000-00A57E401D05");
+    public static final UUID NOTIFICATION_FEEDBACK_CHAR = UUID.fromString("00009002-0000-0000-0000-00A57E401D05");
+}


### PR DESCRIPTION
- Separates module logic and UUID values [similar to btsyncd](https://github.com/AsteroidOS/asteroid-btsyncd/blob/2fe84c78602a33981025c3f00595b443998fd30b/common.h#L47). 
    -The Battery UUID for example was provided by SweetBlue that [we want to remove](#101).
- Notifications are now in their own class
    - Improves readability of the code
    - Simplifies new feature introduction and enables code reuse