### PR TITLE
Sync time on connect and fix actions executed multiple times.

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
+++ b/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
@@ -106,6 +106,7 @@ public class AsteroidBleManager extends BleManager {
                 }
                 recvCallbacks.forEach((characteristic, callback) -> {
                     BluetoothGattCharacteristic characteristic1 = bluetoothGattService.getCharacteristic(characteristic);
+                    removeNotificationCallback(characteristic1);
                     setNotificationCallback(characteristic1).with((device, data) -> callback.call(data.getValue()));
                     enableNotifications(characteristic1).with((device, data) -> callback.call(data.getValue())).enqueue();
                 });

--- a/app/src/main/java/org/asteroidos/sync/connectivity/TimeService.java
+++ b/app/src/main/java/org/asteroidos/sync/connectivity/TimeService.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Handler;
 import android.os.SystemClock;
 
 import org.asteroidos.sync.asteroid.IAsteroidDevice;
@@ -58,6 +59,13 @@ public class TimeService implements IConnectivityService, SharedPreferences.OnSh
 
     @Override
     public final void sync() {
+        Handler handler = new Handler();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                updateTime();
+            }
+        }, 500);
 
         // Register a broadcast handler to use for the alarm Intent
         // Also listen for TIME_CHANGED and TIMEZONE_CHANGED events


### PR DESCRIPTION
Comments should describe the solutions perfectly.

I can't confirm if the `removeNotificationCallback` actually solves the issue where actions are executed multiple times. But it makes sense to have it here too. Initially the idea was not to have this limit, but oh well :wink: 

You can keep this PR open if you prefer, as this issue was only observed a few times by myself.