### PR TITLE
Add custom OWM API Key setting

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/MainActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/MainActivity.java
@@ -31,7 +31,7 @@ import org.asteroidos.sync.asteroid.IAsteroidDevice;
 import org.asteroidos.sync.fragments.AppListFragment;
 import org.asteroidos.sync.fragments.DeviceDetailFragment;
 import org.asteroidos.sync.fragments.DeviceListFragment;
-import org.asteroidos.sync.fragments.PositionPickerFragment;
+import org.asteroidos.sync.fragments.WeatherSettingsFragment;
 import org.asteroidos.sync.services.SynchronizationService;
 import org.asteroidos.sync.utils.AppInfo;
 import org.asteroidos.sync.utils.AppInfoHelper;
@@ -51,7 +51,7 @@ import static android.os.ParcelUuid.fromString;
 public class MainActivity extends AppCompatActivity implements DeviceListFragment.OnDefaultDeviceSelectedListener,
         DeviceListFragment.OnScanRequestedListener, DeviceDetailFragment.OnDefaultDeviceUnselectedListener,
         DeviceDetailFragment.OnConnectRequestedListener, DeviceDetailFragment.OnAppSettingsClickedListener,
-        DeviceDetailFragment.OnLocationSettingsClickedListener, DeviceDetailFragment.OnUpdateListener {
+        DeviceDetailFragment.OnWeatherSettingsClickedListener, DeviceDetailFragment.OnUpdateListener {
 
     public static final String PREFS_NAME = "MainPreferences";
     public static final String PREFS_DEFAULT_MAC_ADDR = "defaultMacAddress";
@@ -285,8 +285,8 @@ public class MainActivity extends AppCompatActivity implements DeviceListFragmen
     }
 
     @Override
-    public void onLocationSettingsClicked() {
-        Fragment f = new PositionPickerFragment();
+    public void onWeatherSettingsClicked() {
+        Fragment f = new WeatherSettingsFragment();
 
         FragmentManager fm = getSupportFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();

--- a/app/src/main/java/org/asteroidos/sync/connectivity/WeatherService.java
+++ b/app/src/main/java/org/asteroidos/sync/connectivity/WeatherService.java
@@ -47,7 +47,8 @@ import github.vatsal.easyweather.retrofit.models.List;
 
 public class WeatherService implements IConnectivityService {
 
-    private static final String owmApiKey = "ffcb5a7ed134aac3d095fa628bc46c65";
+    public static final String PREFS_OWM_API_KEY = "owmApiKey";
+    public static final String PREFS_OWM_API_KEY_DEFAULT = "d2820c63d757912426d74a20e75fb3ce";
 
     public static final String PREFS_NAME = "WeatherPreferences";
     public static final String PREFS_LATITUDE = "latitude";
@@ -72,6 +73,8 @@ public class WeatherService implements IConnectivityService {
     private Float mLatitude;
     private Float mLongitude;
 
+    private String mOwmKey;
+
     public WeatherService(Context ctx, IAsteroidDevice device) {
         mDevice = device;
         mCtx = ctx;
@@ -81,6 +84,7 @@ public class WeatherService implements IConnectivityService {
         mSettings = mCtx.getSharedPreferences(PREFS_NAME, 0);
         mLatitude = mSettings.getFloat(PREFS_LATITUDE, PREFS_LATITUDE_DEFAULT);
         mLongitude = mSettings.getFloat(PREFS_LONGITUDE, PREFS_LONGITUDE_DEFAULT);
+        mOwmKey = mSettings.getString(PREFS_OWM_API_KEY, PREFS_OWM_API_KEY_DEFAULT);
     }
 
     @Override
@@ -162,8 +166,9 @@ public class WeatherService implements IConnectivityService {
     }
 
     private void updateWeather(float latitude, float longitude) {
+        mOwmKey = mSettings.getString(PREFS_OWM_API_KEY, PREFS_OWM_API_KEY_DEFAULT);
 
-        WeatherMap weatherMap = new WeatherMap(mCtx, owmApiKey);
+        WeatherMap weatherMap = new WeatherMap(mCtx, mOwmKey);
         weatherMap.getLocationForecast(String.valueOf(latitude), String.valueOf(longitude), new ForecastCallback() {
             @Override
             public void success(ForecastResponseModel response) {

--- a/app/src/main/java/org/asteroidos/sync/fragments/DeviceDetailFragment.java
+++ b/app/src/main/java/org/asteroidos/sync/fragments/DeviceDetailFragment.java
@@ -71,7 +71,7 @@ public class DeviceDetailFragment extends Fragment {
     private DeviceDetailFragment.OnDefaultDeviceUnselectedListener mDeviceListener;
     private DeviceDetailFragment.OnConnectRequestedListener mConnectListener;
     private DeviceDetailFragment.OnAppSettingsClickedListener mAppSettingsListener;
-    private DeviceDetailFragment.OnLocationSettingsClickedListener mLocationSettingsListener;
+    private DeviceDetailFragment.OnWeatherSettingsClickedListener mWeatherSettingsListener;
     private DeviceDetailFragment.OnUpdateListener mUpdateListener;
 
 
@@ -118,7 +118,7 @@ public class DeviceDetailFragment extends Fragment {
         weatherCard.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mLocationSettingsListener.onLocationSettingsClicked();
+                mWeatherSettingsListener.onWeatherSettingsClicked();
             }
         });
 
@@ -277,11 +277,11 @@ public class DeviceDetailFragment extends Fragment {
             throw new ClassCastException(context.toString()
                     + " does not implement DeviceDetailFragment.OnAppSettingsClickedListener");
 
-        if (context instanceof DeviceDetailFragment.OnLocationSettingsClickedListener)
-            mLocationSettingsListener = (DeviceDetailFragment.OnLocationSettingsClickedListener) context;
+        if (context instanceof DeviceDetailFragment.OnWeatherSettingsClickedListener)
+            mWeatherSettingsListener = (DeviceDetailFragment.OnWeatherSettingsClickedListener) context;
         else
             throw new ClassCastException(context.toString()
-                    + " does not implement DeviceDetailFragment.OnLocationSettingsClickedListener");
+                    + " does not implement DeviceDetailFragment.OnWeatherSettingsClickedListener");
 
         if (context instanceof DeviceDetailFragment.OnUpdateListener)
             mUpdateListener = (DeviceDetailFragment.OnUpdateListener) context;
@@ -299,8 +299,8 @@ public class DeviceDetailFragment extends Fragment {
         void onAppSettingsClicked();
     }
 
-    public interface OnLocationSettingsClickedListener {
-        void onLocationSettingsClicked();
+    public interface OnWeatherSettingsClickedListener {
+        void onWeatherSettingsClicked();
     }
 
     public interface OnConnectRequestedListener {

--- a/app/src/main/res/layout/dialog_api_key.xml
+++ b/app/src/main/res/layout/dialog_api_key.xml
@@ -1,0 +1,16 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <EditText
+        android:id="@+id/apikey"
+        android:inputType="text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        android:hint="@string/OWM_API_KEY"
+        android:autofillHints="" />
+</LinearLayout>

--- a/app/src/main/res/menu/owm_position_picker_menu.xml
+++ b/app/src/main/res/menu/owm_position_picker_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/customApiKey"
+        android:title="@string/set_owm_api_key"
+        android:orderInCategory="100"
+        app:showAsAction="never"/>
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,4 +68,8 @@
     <string name="dialer">Telefon</string>
     <string name="intro_slideandroidgo_title">Android Go</string>
     <string name="intro_slideandroidgo_subtitle">Android Go ist nicht unterstützt, da es keinen Benachrichtigungszugriff erlaubt und Hintergrundprozesse einschränkt. Für Root-Nutzer besteht die Möglichkeit die \"ro.config.low_ram\" Variable in der build.prop Datei auf \"false\" zu setzen.</string>
+    <string name="apply">Bestätigen</string>
+    <string name="cancel">Abbrechen</string>
+    <string name="OWM_API_KEY">OWM API Schlüssel</string>
+    <string name="set_owm_api_key">OWM API Schlüssel eingeben</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,4 +69,8 @@
     <string name="intro_phonestateslide_title">Phone &amp; Contacts</string>
     <string name="show_calls_on_watch">Display incoming calls</string>
     <string name="dialer">Dialer</string>
+    <string name="set_owm_api_key">Set custom OWM API Key</string>
+    <string name="OWM_API_KEY">OWM API Key</string>
+    <string name="apply">Apply</string>
+    <string name="cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
- Add an EditText for the user to input their own API Key.
- The Weather Service now loads the SharedPreference String for the API
  key on every weather refresh to use the latest API key without
  restarting the app.