### PR TITLE
Prompt to enable location before scanning.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="OWM_API_KEY">OWM API Key</string>
     <string name="apply">Apply</string>
     <string name="cancel">Cancel</string>
+    <string name="location_disabled_message">In order to find watches the location service has to be enabled. Once paired you can safely disable it again.</string>
+    <string name="location_disabled_title">Location disabled</string>
 </resources>


### PR DESCRIPTION
Having the location permission is not enough to successfully scan for watches.
Instead we need to ensure that locations are actually enabled too.

The logic is slightly changed so that Bluetooth is only enabled at app start (no need to scan when already paired).
If already paired, simply connect to the watch.
If not paired, prompt to enable location when not enabled, once enabled start scanning, else quit the app.

This solves https://github.com/AsteroidOS/AsteroidOSSync/issues/145.