### PR TITLE
PermissionsActivity: Ask for BLUETOOTH_SCAN permission too.

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
+++ b/app/src/main/java/org/asteroidos/sync/PermissionsActivity.java
@@ -68,7 +68,7 @@ public class PermissionsActivity extends MaterialIntroActivity {
                     .description(getString(R.string.intro_slide3_subtitle));
 
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                localizationFragmentBuilder.neededPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.BLUETOOTH_CONNECT});
+                localizationFragmentBuilder.neededPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.BLUETOOTH_CONNECT, Manifest.permission.BLUETOOTH_SCAN});
             }
             SlideFragment localizationFragment = localizationFragmentBuilder.build();
 
@@ -77,6 +77,8 @@ public class PermissionsActivity extends MaterialIntroActivity {
             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 localizationFragmentShown |= (ContextCompat.checkSelfPermission(this,
                         Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED);
+                localizationFragmentShown |= (ContextCompat.checkSelfPermission(this,
+                        Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED);
             }
 
             NotificationsSlide notificationFragment = new NotificationsSlide();


### PR DESCRIPTION
Now this is a weird one. After another Android 12 update the app was crashing again. The log shows:
```
01-24 20:41:21.084  8811  8811 E AndroidRuntime: FATAL EXCEPTION: main
01-24 20:41:21.084  8811  8811 E AndroidRuntime: Process: org.asteroidos.sync, PID: 8811
01-24 20:41:21.084  8811  8811 E AndroidRuntime: java.lang.SecurityException: Need android.permission.BLUETOOTH_SCAN permission for AttributionSource { uid = 10829, packageName = org.asteroidos.sync, attributionTag = null, token = android.os.BinderProxy@e7f7b8c, next = null }: GattService registerScanner
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Parcel.createExceptionOrNull(Parcel.java:2437)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Parcel.createException(Parcel.java:2421)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Parcel.readException(Parcel.java:2404)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Parcel.readException(Parcel.java:2346)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.bluetooth.IBluetoothGatt$Stub$Proxy.registerScanner(IBluetoothGatt.java:1886)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.bluetooth.le.BluetoothLeScanner$BleScanCallbackWrapper.startRegistration(BluetoothLeScanner.java:519)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.bluetooth.le.BluetoothLeScanner.startScan(BluetoothLeScanner.java:305)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.bluetooth.le.BluetoothLeScanner.startScan(BluetoothLeScanner.java:161)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerImplLollipop.startScanInternal(BluetoothLeScannerImplLollipop.java:85)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat.startScan(BluetoothLeScannerCompat.java:159)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at org.asteroidos.sync.MainActivity.lambda$btEnableAndScan$3$MainActivity(MainActivity.java:384)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at org.asteroidos.sync.-$$Lambda$MainActivity$3S-J7Ow_XLkNwg6HYugLsVdWUVI.run(Unknown Source:2)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:938)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:226)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:313)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:8633)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
01-24 20:41:21.084  8811  8811 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1133)
```

The solution is again obvious: Ask for the required permission. BUT, the permission prompt never really shows. Yet the permission is granted anyway and the scanning works fine.