### PR TITLE
gradle: Switch EasyWeather package to fix http/https issues.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("com.google.android.material:material:1.6.1")
-    implementation("com.github.code-crusher:EasyWeather:1.2")
+    implementation("com.github.MagneFire:EasyWeather:1.3")
     implementation("com.google.code.gson:gson:2.9.1")
     implementation("org.osmdroid:osmdroid-android:6.1.14")
     implementation("no.nordicsemi.android.support.v18:scanner:1.6.0")


### PR DESCRIPTION
The original EasyWeather library doesn't use https to access the Open Weather map, which is now required. Switch to a different package with this fix applied since the original maintainer didn't update the library to fix this issue (https://github.com/MagneFire/EasyWeather/commit/4fb154e747c472c8b24bb1468304dce97a936f00).

This provides a workaround to #175. 