### PR TITLE
increase app version to 0.27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "org.asteroidos.sync"
         minSdk = 24
         targetSdk = 33
-        versionCode = 26
-        versionName = "0.26"
+        versionCode = 27
+        versionName = "0.27"
     }
     buildTypes {
         named("release") {

--- a/fastlane/metadata/android/en-US/changelogs/27.txt
+++ b/fastlane/metadata/android/en-US/changelogs/27.txt
@@ -1,0 +1,4 @@
+0.27
+  * Improved Android 12+ support (Thanks dv1!)
+    * The Bluetooth connection process has been improved.
+  * Translation improvements


### PR DESCRIPTION
This follows up to the recent improvements to Bluetooth on Android 12+ devices: https://github.com/AsteroidOS/AsteroidOSSync/pull/187

  * Improved Android 12+ support (Thanks dv1!)
    * The Bluetooth connection process has been improved.
  * Translation improvements

