### PR TITLE
Properly split GATT write to fit in Android 13 BLE stack limit

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
+++ b/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
@@ -59,7 +59,7 @@ public class AsteroidBleManager extends BleManager {
 
     public final void send(UUID characteristic, byte[] data) {
         writeCharacteristic(sendingCharacteristics.get(characteristic), data,
-                Objects.requireNonNull(sendingCharacteristics.get(characteristic)).getWriteType()).enqueue();
+                Objects.requireNonNull(sendingCharacteristics.get(characteristic)).getWriteType()).split().enqueue();
     }
 
     @NonNull


### PR DESCRIPTION
Android 13 switched Bluetooth stack to Gabledorsche. The stack is known to crash when trying to send large payload.

related SO article: https://stackoverflow.com/questions/73772158/bluetoothgattcharacteristic-write-crashes-with-android-13

This fixes issue #192 