### PR TITLE
MediaService: Do not attempt to add a sessions listener whenever the session manager isn't available.

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/connectivity/MediaService.java
+++ b/app/src/main/java/org/asteroidos/sync/connectivity/MediaService.java
@@ -164,7 +164,9 @@ public class MediaService implements IConnectivityService,  MediaSessionManager.
                 Handler handler = new Handler(Looper.getMainLooper());
                 handler.post(() -> {
                     onActiveSessionsChanged(controllers);
-                    mMediaSessionManager.addOnActiveSessionsChangedListener(this, new ComponentName(mCtx, NLService.class));
+                    if (mMediaSessionManager != null) {
+                        mMediaSessionManager.addOnActiveSessionsChangedListener(this, new ComponentName(mCtx, NLService.class));
+                    }
                 });
             } catch (SecurityException e) {
                 Log.w(TAG, "No Notification Access");


### PR DESCRIPTION
I could not reproduce the issue mentioned in #209... But I've added a `null` check to prevent the issue from happening.


This may fix #209.