### PR TITLE
Add adaptive icon

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
 
+    - name: Archive linter results
+      uses: actions/upload-artifact@v3
+      with:
+        name: lint-result.html
+        path: app/build/reports/lint-results-debug.html
+
     - name: Archive debug.apk
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
 
     - name: Grant execute permission for gradlew

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,3 +25,9 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+
+    - name: Archive debug.apk
+      uses: actions/upload-artifact@v3
+      with:
+        name: asteroidossync-debug.apk
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,5 +62,5 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("org.osmdroid:osmdroid-android:6.1.16")
     implementation("no.nordicsemi.android.support.v18:scanner:1.6.0")
-    implementation("no.nordicsemi.android:ble:2.6.0")
+    implementation("no.nordicsemi.android:ble:2.7.2")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     lint {
         checkReleaseBuilds = true

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
This PR adds:

- a monochromatic icon: enables themed icon support on Android 13+
 
 <img src="https://github.com/AsteroidOS/AsteroidOSSync/assets/14153182/b3c68429-95c9-4148-9e9f-36558d44616e" height="250px" />

- stores the `debug.apk` artifact and the linter results of GitHub Action workflows
- increases the nordic ble lib to 2.7.2
    - increases JDK to Java 17
