### PR TITLE
Save the state of the ringer regardless of its original status during connection to watch

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/connectivity/SilentModeService.java
+++ b/app/src/main/java/org/asteroidos/sync/connectivity/SilentModeService.java
@@ -44,10 +44,11 @@ public class SilentModeService implements SharedPreferences.OnSharedPreferenceCh
         if (notificationPref == null) {
             notificationPref = prefs.getBoolean(PREF_RINGER, false);
 
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putInt(PREF_ORIG_RINGER, am.getRingerMode());
+            editor.apply();
+
             if (notificationPref) {
-                SharedPreferences.Editor editor = prefs.edit();
-                editor.putInt(PREF_ORIG_RINGER, am.getRingerMode());
-                editor.apply();
                 am.setRingerMode(AudioManager.RINGER_MODE_SILENT);
             }
         }


### PR DESCRIPTION
Unchecking 'Silence the phone when connected' was not returning my phone to 'vibrate mode' correctly, this change saves the state of the ringer regardless of its status during connection, allowing to correctly set it back when 'silence the phone' is unchecked.

This should address issue #148 

PS. I am not an Android developer, so let me know if this change can be done in other, more appropriate way.