### PR TITLE
Cap GATT write chunks at 512 bytes to fix crash on Android 13+

### DIFF
--- a/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
+++ b/app/src/main/java/org/asteroidos/sync/asteroid/AsteroidBleManager.java
@@ -40,8 +40,30 @@ import java.util.UUID;
 
 import no.nordicsemi.android.ble.BleManager;
 import no.nordicsemi.android.ble.data.Data;
+import no.nordicsemi.android.ble.data.DataSplitter;
 
 public class AsteroidBleManager extends BleManager {
+    // Android's BluetoothGatt.writeCharacteristic() rejects any value longer
+    // than the maximum GATT attribute length (512 bytes) since Android 13,
+    // throwing IllegalArgumentException. The default MTU-based splitter chunks
+    // at MTU - 3 bytes, which is 514 when the system negotiates the maximum MTU
+    // of 517 (as on the Pixel 8), exceeding the limit and crashing the app on
+    // the first long notification. Cap each chunk at 512 bytes regardless of
+    // the negotiated MTU. The watch reassembles the message from the chunks, so
+    // a smaller chunk size has no effect other than splitting into more writes.
+    private static final int MAX_ATTRIBUTE_LENGTH = 512;
+
+    private static final DataSplitter CAPPED_SPLITTER = (message, index, maxLength) -> {
+        final int size = Math.min(maxLength, MAX_ATTRIBUTE_LENGTH);
+        final int offset = index * size;
+        if (offset >= message.length)
+            return null;
+        final int length = Math.min(size, message.length - offset);
+        final byte[] chunk = new byte[length];
+        System.arraycopy(message, offset, chunk, 0, length);
+        return chunk;
+    };
+
     public static final String TAG = AsteroidBleManager.class.toString();
     @Nullable
     public BluetoothGattCharacteristic batteryCharacteristic;
@@ -59,7 +81,7 @@ public class AsteroidBleManager extends BleManager {
 
     public final void send(UUID characteristic, byte[] data) {
         writeCharacteristic(sendingCharacteristics.get(characteristic), data,
-                Objects.requireNonNull(sendingCharacteristics.get(characteristic)).getWriteType()).split().enqueue();
+                Objects.requireNonNull(sendingCharacteristics.get(characteristic)).getWriteType()).split(CAPPED_SPLITTER).enqueue();
     }
 
     @NonNull


### PR DESCRIPTION
## Summary

On recent Android versions the app stays open for a few seconds and then closes
when connecting to the watch. This pull request fixes that crash. It was
reproduced on a Pixel 8 (Android 14/15) and matches the reports in #217 and
#203.

## Root cause

`AsteroidBleManager.send()` writes characteristics with the default `.split()`
splitter (added in #195), which chunks data at `MTU - 3` bytes. When the system
negotiates the maximum MTU of 517, as the Pixel 8 does, each chunk is 514 bytes.
Since Android 13, `BluetoothGatt.writeCharacteristic()` rejects any value longer
than 512 bytes (the maximum GATT attribute length) and throws
`IllegalArgumentException`, so the app crashes on the first notification whose
payload exceeds 512 bytes, a few seconds after connecting to the watch.

The existing `requestMtu(256)` call does not help, because the connection has
already negotiated an MTU of 517 by the time it runs:

```
configureMTU() mtu: 256
GATTC_UpdateUserAttMtuIfNeeded: current mtu: 517, max_user_mtu: 256
onConfigureMTU(..., 517, 0)
```

```
java.lang.IllegalArgumentException: value should not be longer than max length of an attribute value
    at android.bluetooth.BluetoothGatt.writeCharacteristic(BluetoothGatt.java:1451)
    at no.nordicsemi.android.ble.BleManagerHandler.internalWriteCharacteristic(...)
```

## Fix

Use a custom `DataSplitter` that caps each chunk at 512 bytes regardless of the
negotiated MTU. The watch reassembles the message from the chunks, so a smaller
chunk size only changes the number of writes, not the result.

## Testing

Built and installed on a Pixel 8 (Android 14/15). The app no longer closes after
a few seconds, and notifications reach the watch, including ones larger than 512
bytes that previously triggered the crash.

Fixes #217.

Thanks for AsteroidOS and for maintaining this app. Best regards from France.
